### PR TITLE
🐛 FIX: Update contributor (#68)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Boutique ===
-Contributors:      automattic, jameskoster, tiagonoronha
+Contributors:      woocommerce, automattic, jameskoster, tiagonoronha
 Tags:              e-commerce, light, dark, two-columns, right-sidebar, responsive-layout, accessibility-ready
 Requires at least: 4.0
 Tested up to:      5.2


### PR DESCRIPTION
Fixes #68 

Added `woocommerce` to the list of contributors.

### How to test the changes in this Pull Request:

1. Head over to `/wp-admin/themes.php` and activate the Boutique child-theme
2. Head over to `/wp-admin/theme-editor.php?file=readme.txt&theme=boutique` and look up the `Contributors`

### Changelog

> Fix - Update the list of contributors. #68