### PR TITLE
Better badge colors in cart and checkout block

### DIFF
--- a/inc/class-boutique-customizer.php
+++ b/inc/class-boutique-customizer.php
@@ -123,6 +123,7 @@ class Boutique_Customizer {
 	public function add_customizer_css() {
 		$header_background_color 		= get_theme_mod( 'storefront_header_background_color' );
 		$header_text_color 				= get_theme_mod( 'storefront_header_text_color' );
+		$button_background_color 				= get_theme_mod( 'storefront_button_background_color' );
 
 		$style = '
 			.main-navigation ul.menu > li > ul,
@@ -170,7 +171,13 @@ class Boutique_Customizer {
 
 			.main-navigation ul li.smm-active li ul.products li.product h3 {
 				color: ' . $header_text_color . ';
-			}';
+			}
+
+			.wc-block-components-order-summary-item__quantity {
+				background-color: '. $button_background_color .';
+				box-shadow: 0 0 0 2px '. $button_background_color .';
+			}'
+		;
 
 		wp_add_inline_style( 'storefront-child-style', $style );
 	}


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #82 

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
Similar solution to the issue in deli. See [here](https://github.com/woocommerce/deli/pull/66/files)
We had to use different theme mod because the same solution ended in the text having same color as background.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/17932063/119008682-ad5f4d80-b992-11eb-9fd4-205d416426fa.png)

After:
![image](https://user-images.githubusercontent.com/17932063/119008788-c23be100-b992-11eb-9cad-b3025762132a.png)


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1.
2.
3.

### Changelog

> Change colors in cart badges

### Tests

- [x] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
