### PR TITLE
Using button alternate text color for credit card box background in t…

### DIFF
--- a/inc/class-boutique-customizer.php
+++ b/inc/class-boutique-customizer.php
@@ -124,6 +124,7 @@ class Boutique_Customizer {
 		$header_background_color 		= get_theme_mod( 'storefront_header_background_color' );
 		$header_text_color 				= get_theme_mod( 'storefront_header_text_color' );
 		$button_background_color 				= get_theme_mod( 'storefront_button_background_color' );
+		$button_alt_text_color 				= get_theme_mod( 'storefront_button_alt_text_color' );
 
 		$style = '
 			.main-navigation ul.menu > li > ul,
@@ -176,7 +177,12 @@ class Boutique_Customizer {
 			.wc-block-components-order-summary-item__quantity {
 				background-color: '. $button_background_color .';
 				box-shadow: 0 0 0 2px '. $button_background_color .';
-			}'
+			}
+			
+			.wc-block-cart__submit-container {
+				background-color: '. $button_alt_text_color . ';
+			}
+			'
 		;
 
 		wp_add_inline_style( 'storefront-child-style', $style );


### PR DESCRIPTION
…he cart block

<!-- Reference any related issues or PRs here -->
Fixes #81 

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

After:
![image](https://user-images.githubusercontent.com/17932063/122379997-b3cbef80-cf67-11eb-9a61-fce9bdcaaa3a.png)

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1.
2.
3.

### Changelog

> Using button alternate text color for credit card box background in the cart block

### Tests

- [ ] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
